### PR TITLE
Remove log from 'hangupCall' action click

### DIFF
--- a/src/FixCallRaceConditionPlugin.tsx
+++ b/src/FixCallRaceConditionPlugin.tsx
@@ -61,7 +61,7 @@ export default class FixCallRaceConditionPlugin extends FlexPlugin {
             // and ask them if they want to hang it up
             if (this.ifFlavorOne(connection, task)) {
                 Notifications.showNotification(this.notificationID, {
-                    onHangup: () => this.hangupCallAndLog(1, "timeout")
+                    onHangup: () => this.hangupCall()
                 });
                 return;
             }
@@ -114,4 +114,8 @@ export default class FixCallRaceConditionPlugin extends FlexPlugin {
             `Voice call race condition detected - Scenario 1, flavour ${flavour}. Hanging an invalid call down on ${event}.`
         );
     };
+
+    hangupCall = () => {
+        Actions.invokeAction("HangupCall", { task: {} });
+    }
 }


### PR DESCRIPTION
Flex 1.15.0 provides logs for stuck calls, so we need to remove it from the plugin to avoid duped logs.

I'm leaving the logs on _before_ actions as the plugin basically will solve the issue before Flex logs kick in.